### PR TITLE
[Sync] Update project files from source repository (77a91d0)

### DIFF
--- a/.github/actions/setup-go-with-cache/action.yml
+++ b/.github/actions/setup-go-with-cache/action.yml
@@ -211,6 +211,7 @@ runs:
 
     # --------------------------------------------------------------------
     # Go module cache (shared across versions)
+    # Uses actions/cache which handles both restore and save
     # --------------------------------------------------------------------
     - name: 💾 Go module cache
       id: restore-gomod
@@ -284,6 +285,7 @@ runs:
 
     # --------------------------------------------------------------------
     # Go build cache (per-version)
+    # Uses actions/cache which handles both restore and save
     # --------------------------------------------------------------------
     - name: 💾 Go build cache
       id: restore-gobuild

--- a/.github/workflows/fortress-pre-commit.yml
+++ b/.github/workflows/fortress-pre-commit.yml
@@ -291,6 +291,8 @@ jobs:
       - name: 🔨 Install go-pre-commit tool
         if: steps.go-pre-commit-cache.outputs.cache-hit != 'true' || env.GO_PRE_COMMIT_USE_LOCAL == 'true'
         id: install-pre-commit
+        env:
+          GH_TOKEN: ${{ secrets.github-token || github.token }}
         run: |
           # Check if we should use local development version
           if [[ "${{ env.GO_PRE_COMMIT_USE_LOCAL }}" == "true" ]]; then
@@ -330,24 +332,90 @@ jobs:
             echo "install_success=true" >> $GITHUB_OUTPUT
             echo "version=$VERSION" >> $GITHUB_OUTPUT
           else
-            # Use production version
+            # Use production version - download pre-built binary from GitHub releases
             VERSION="${{ env.GO_PRE_COMMIT_VERSION }}"
-            echo "⬇️ Cache miss – installing go-pre-commit version: $VERSION"
+            echo "⬇️ Cache miss – downloading go-pre-commit version: $VERSION"
 
-            # Install using go install
-            go install github.com/mrz1836/go-pre-commit/cmd/go-pre-commit@$VERSION
+            # Detect platform and architecture
+            OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+            ARCH=$(uname -m)
 
-            # Copy the freshly installed binary to cache directory
+            # Map architecture names
+            case "$ARCH" in
+              x86_64|amd64) ARCH="amd64" ;;
+              aarch64|arm64) ARCH="arm64" ;;
+              *) echo "❌ Unsupported architecture: $ARCH" && exit 1 ;;
+            esac
+
+            # Map OS names
+            case "$OS" in
+              linux) OS="linux" ;;
+              macos) OS="darwin" ;;
+              windows) OS="windows" ;;
+              *) echo "❌ Unsupported OS: $OS" && exit 1 ;;
+            esac
+
+            echo "📋 Detected platform: ${OS}_${ARCH}"
+
+            # Clean version (remove 'v' prefix if present)
+            CLEAN_VERSION="${VERSION#v}"
+
+            # Build asset name and download using gh CLI
+            ASSET_NAME="go-pre-commit_${CLEAN_VERSION}_${OS}_${ARCH}.tar.gz"
+            echo "📥 Downloading asset: $ASSET_NAME from mrz1836/go-pre-commit@$VERSION"
+
+            # Download and extract
+            TEMP_DIR=$(mktemp -d)
+            cd "$TEMP_DIR"
+
+            if gh release download "$VERSION" \
+                --repo mrz1836/go-pre-commit \
+                --pattern "$ASSET_NAME" \
+                --dir .; then
+              echo "✅ Download successful"
+            else
+              echo "❌ Download failed for $ASSET_NAME from mrz1836/go-pre-commit@$VERSION"
+              exit 1
+            fi
+
+            # Extract the tarball
+            if tar -xzf "$ASSET_NAME"; then
+              echo "✅ Extraction successful"
+            else
+              echo "❌ Extraction failed"
+              exit 1
+            fi
+
+            # Find the go-pre-commit binary
+            PRE_COMMIT_BINARY=$(find . -name "go-pre-commit" -type f | head -1)
+            if [[ -z "$PRE_COMMIT_BINARY" ]]; then
+              echo "❌ Could not find go-pre-commit binary in extracted files"
+              ls -la
+              exit 1
+            fi
+
+            echo "✅ Found go-pre-commit binary at: $PRE_COMMIT_BINARY"
+
+            # Make it executable and copy to cache directory
+            chmod +x "$PRE_COMMIT_BINARY"
             mkdir -p ~/.cache/go-pre-commit-bin
-            cp "$(go env GOPATH)/bin/go-pre-commit" ~/.cache/go-pre-commit-bin/
+            cp "$PRE_COMMIT_BINARY" ~/.cache/go-pre-commit-bin/go-pre-commit
+
+            # Copy to GOPATH/bin for immediate use
+            mkdir -p "$(go env GOPATH)/bin"
+            cp ~/.cache/go-pre-commit-bin/go-pre-commit "$(go env GOPATH)/bin/go-pre-commit"
 
             # Store the validated binary path
             GO_BIN="$(go env GOPATH)/bin"
             GO_PRE_COMMIT_PATH="$GO_BIN/go-pre-commit"
             echo "GO_PRE_COMMIT_BINARY=$GO_PRE_COMMIT_PATH" >> $GITHUB_ENV
 
+            # Cleanup temp directory
+            cd /
+            rm -rf "$TEMP_DIR"
+
             # Verify installation
-            echo "✅ go-pre-commit installed and stored in cache"
+            echo "✅ go-pre-commit downloaded and stored in cache"
             VERSION_OUTPUT=$("$GO_BIN/go-pre-commit" --version 2>&1 | head -1 || echo "$VERSION")
             echo "🏷️ Version: $VERSION_OUTPUT"
             echo "install_success=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What Changed

* Added explanatory comments to `.github/actions/setup-go-with-cache/action.yml` clarifying that `actions/cache` handles both restore and save operations for Go module cache and Go build cache
* Modified the go-pre-commit installation process in `.github/workflows/fortress-pre-commit.yml` to download pre-built binaries from GitHub releases instead of using `go install`
* Added `GH_TOKEN` environment variable to the install step using `secrets.github-token || github.token` for authenticated GitHub API access
* Implemented platform and architecture detection logic that maps `runner.os` and `uname -m` output to standardized OS/ARCH values (linux/darwin/windows and amd64/arm64)
* Changed installation comments from "installing go-pre-commit" to "downloading go-pre-commit" to reflect the new binary download approach

## Why It Was Necessary

* Pre-built binaries provide faster installation times compared to compiling from source with `go install`, reducing CI workflow duration
* Binary downloads eliminate the need for Go compilation during workflow runs, simplifying dependencies
* Platform detection ensures the correct binary variant is downloaded for the runner's operating system and architecture

## Testing Performed

* Verify the workflow runs successfully on different runner OS configurations (Linux, macOS, Windows)
* Test that architecture detection correctly maps x86_64/amd64 and aarch64/arm64 variants
* Confirm the GH_TOKEN fallback mechanism works with both secrets.github-token and github.token
* Validate that cache behavior remains unchanged with the added explanatory comments

## Impact / Risk

* **Low Risk**: Changes are isolated to CI/CD workflows and don't affect application code
* **Performance Improvement**: Binary downloads should significantly reduce go-pre-commit installation time in CI
* **Potential Issue**: Requires GitHub releases to have pre-built binaries available for all supported platforms, or the workflow will fail with unsupported architecture/OS errors

<!-- go-broadcast-metadata
group:
  id: bsv-blockchain-spv
  name: bsv-blockchain-spv
diff_info:
  staged_repo_available: true
  changed_files_count: 2
  files_with_original_content: 2
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 77a91d04834f5ae7b45eeff802ee4e79568c57c0
  target_repo: bsv-blockchain/spv-wallet-admin-keygen
  sync_commit: 65080005262009203494b6076e0b89923574d81e
  sync_time: 2026-03-20T13:05:43-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 365
  - src: .github/actions
    dest: .github/actions
    files_synced: 1
    files_examined: 18
    files_excluded: 0
    processing_time_ms: 1113
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 410
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 577
  - src: .github/scripts
    dest: .github/scripts
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 282
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1055
  - src: .github/workflows
    dest: .github/workflows
    files_synced: 1
    files_examined: 26
    files_excluded: 0
    processing_time_ms: 1874
  - src: .vscode
    dest: .vscode
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 399
performance:
  total_files: 100
-->
